### PR TITLE
refactor: pin GitHub Actions

### DIFF
--- a/.github/actions/pnpm-init/action.yml
+++ b/.github/actions/pnpm-init/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: 🆙 Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         run_install: false
 

--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
@@ -22,7 +22,7 @@ jobs:
         run: pnpm build
 
       - name: ⏫ Upload app
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: astro-app
           path: apps/astro/dist

--- a/.github/workflows/01-lint.yml
+++ b/.github/workflows/01-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init

--- a/.github/workflows/02-deploy-gh-pages.yml
+++ b/.github/workflows/02-deploy-gh-pages.yml
@@ -15,19 +15,19 @@ jobs:
       contents: write
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
 
       - name: ⏬ Download patternhub
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: astro-app
           path: apps/astro/dist
 
       - name: 🥅 Deploy to GH-Pages
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./apps/astro/dist

--- a/.github/workflows/99-auto-merge.yml
+++ b/.github/workflows/99-auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: ⏬ Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -39,7 +39,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
@@ -48,7 +48,7 @@ jobs:
           pnpm build --filter @db-ux/create-astro
 
       - id: changesets
-        uses: changesets/action@v1.9.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset publish
           title: 'chore: version packages'


### PR DESCRIPTION
We'd like to even also pin our GitHub Actions similar to how we do it for other dependencies like pnpm as well. And we should use SHA references instead of tags to ensure an immutable reference. The versions would still be stored as a comment afterwards, which is best practice and works well with dependabot.

Tags are mutable — anyone with push access to an action's repository can move a tag to point to a different commit, potentially injecting malicious code into your workflows. Pinning to the full commit SHA makes each reference immutable: even if a tag is tampered with, your workflows will continue using the exact code you reviewed and approved. The version comment (`# v6.0.3`) preserves readability and allows Dependabot to detect and propose updates when a new version is released.